### PR TITLE
Add winblend option for floating window

### DIFF
--- a/doc/scrollbar.txt
+++ b/doc/scrollbar.txt
@@ -32,7 +32,7 @@ Config
 >
   augroup your_config_scrollbar_nvim
       autocmd!
-      autocmd CursorMoved,VimResized,QuitPre * silent! lua require('scrollbar').show()
+      autocmd WinScrolled,VimResized,QuitPre * silent! lua require('scrollbar').show()
       autocmd WinEnter,FocusGained           * silent! lua require('scrollbar').show()
       autocmd WinLeave,BufLeave,BufWinLeave,FocusLost            * silent! lua require('scrollbar').clear()
   augroup end
@@ -91,5 +91,13 @@ Set scrollbar width. By default it is set to 1.
 >
   let g:scrollbar_width = 1
 <
+
+                                                        *g:scrollbar_winblend*
+Set pseudo-transparency for scrollbar floating window.
+Check 'winblend' for more info. By default it is set to 0 (disabled).
+>
+  let g:scrollbar_winblend = 0
+
+
 
  vim: ft=help tw=78 et ts=2 sw=2 sts=2 norl

--- a/lua/scrollbar.lua
+++ b/lua/scrollbar.lua
@@ -9,6 +9,7 @@ local default = {
     width = 1,
     right_offset = 1,
     excluded_filetypes = {},
+    winblend = 0,
     shape = {
         head = "▲",
         body = "█",
@@ -150,6 +151,7 @@ function M.show(winnr, bufnr)
         bar_bufnr = create_buf(bar_size, bar_lines)
         bar_winnr = api.nvim_open_win(bar_bufnr, false, opts)
         api.nvim_win_set_option(bar_winnr, "winhl", "Normal:ScrollbarWinHighlight")
+        api.nvim_win_set_option(bar_winnr, "winblend", option.winblend)
     end
 
     api.nvim_buf_set_var(bufnr, "scrollbar_state", {


### PR DESCRIPTION
Set pseudo-transparency for scrollbar floating window.
Check 'winblend' for more info. By default it is set to 0 (disabled).

```vim
let g:scrollbar_winblend = 100
```